### PR TITLE
Preserve isInitialRender during effects

### DIFF
--- a/src/__tests__/addIsInitialRender.tsx
+++ b/src/__tests__/addIsInitialRender.tsx
@@ -2,7 +2,13 @@ import React, {FC} from 'react'
 import {render, screen} from '@testing-library/react'
 import '@testing-library/jest-dom'
 import '@testing-library/jest-dom/extend-expect'
-import {flowMax} from 'ad-hok'
+import {
+  flowMax,
+  addEffect,
+  addStateHandlers,
+  addProps,
+  addLayoutEffect,
+} from 'ad-hok'
 
 import {addIsInitialRender} from '..'
 
@@ -13,16 +19,44 @@ describe('addIsInitialRender()', () => {
     }
 
     const Component: FC<Props> = flowMax(
+      addStateHandlers(
+        {
+          numInitialTriggers: 0,
+          numInitialLayoutTriggers: 0,
+        },
+        {
+          triggerInitial: ({numInitialTriggers}) => () => ({
+            numInitialTriggers: numInitialTriggers + 1,
+          }),
+          triggerInitialLayout: ({numInitialLayoutTriggers}) => () => ({
+            numInitialLayoutTriggers: numInitialLayoutTriggers + 1,
+          }),
+        },
+      ),
       addIsInitialRender,
-      ({isInitialRender}) => (
-        <div data-testid={testId}>{isInitialRender ? 'yes' : 'no'}</div>
+      addEffect(({triggerInitial, isInitialRender}) => () => {
+        if (isInitialRender) triggerInitial()
+      }),
+      addLayoutEffect(({isInitialRender, triggerInitialLayout}) => () => {
+        if (isInitialRender) triggerInitialLayout()
+      }),
+      addProps(
+        ({isInitialRender}) => ({
+          x: isInitialRender ? 1 : 2,
+        }),
+        [],
+      ),
+      ({numInitialTriggers, x, numInitialLayoutTriggers}) => (
+        <div data-testid={testId}>
+          {numInitialTriggers} {x} {numInitialLayoutTriggers}
+        </div>
       ),
     )
 
     const testId = 'is-initial-render'
     const {rerender} = render(<Component testId={testId} />)
-    expect(screen.getByTestId(testId)).toHaveTextContent('yes')
+    expect(screen.getByTestId(testId)).toHaveTextContent('1 1 1')
     rerender(<Component testId={testId} />)
-    expect(screen.getByTestId(testId)).toHaveTextContent('no')
+    expect(screen.getByTestId(testId)).toHaveTextContent('1 1 1')
   })
 })

--- a/src/addIsInitialRender.tsx
+++ b/src/addIsInitialRender.tsx
@@ -1,21 +1,23 @@
 import {addRef, addProps, flowMax, SimplePropsAdder} from 'ad-hok'
 
-import addEffectOnMount from './addEffectOnMount'
 import cleanupProps from './cleanupProps'
 
 type AddIsInitialRenderType = SimplePropsAdder<{
   isInitialRender: boolean
 }>
 
-const refName = 'isInitialRenderRef'
+const refName = '_isInitialRender-ref'
 
 const addIsInitialRender: AddIsInitialRenderType = flowMax(
-  addRef(refName, true),
-  addEffectOnMount(({[refName]: ref}) => () => {
-    ref.current = false
+  addRef(refName, 0),
+  addProps(({[refName]: ref}) => {
+    if (ref.current <= 2) {
+      ref.current = ref.current + 1
+    }
+    return {}
   }),
-  addProps(({[refName]: {current: isInitialRender}}) => ({
-    isInitialRender,
+  addProps(({[refName]: {current: numRenders}}) => ({
+    isInitialRender: numRenders < 2,
   })),
   cleanupProps([refName]),
 )


### PR DESCRIPTION
In this PR:
- update `addIsInitialRender()` so that `isInitialRender` is true during effects that run after the initial render cycle

Fixes #16 