### PR TITLE
addReducerOverProps() accept initial state as function of props

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ const MyComponent: FC = flowMax(
 ```js
 addReducerOverProps: (
   reducer: (props: Object) => ReducerFunction,
-  initialState: Object
+  initialState: Object | (props: Object) => Object
 ): Function
 ```
 

--- a/src/__tests__/addReducerOverProps.tsx
+++ b/src/__tests__/addReducerOverProps.tsx
@@ -74,4 +74,72 @@ describe('addReducerOverProps()', () => {
     expect(screen.getByTestId(testId)).toHaveTextContent('4')
     expect(screen.getByTestId(`${testId}-y`)).toHaveTextContent('10')
   })
+  test('accepts initial values as function of props', () => {
+    interface Props {
+      x: number
+      initialY: number
+      testId: string
+    }
+
+    interface ReducerState {
+      y: number
+    }
+
+    type ReducerAction =
+      | {type: 'incrementByX'}
+      | {type: 'incrementByAmount'; amount: number}
+
+    const Component: FC<Props> = flowMax(
+      addReducerOverProps(
+        ({x}) => (state: ReducerState, action: ReducerAction) => {
+          switch (action.type) {
+            case 'incrementByX':
+              return {
+                ...state,
+                y: state.y + x,
+              }
+            case 'incrementByAmount':
+              return {
+                ...state,
+                y: state.y + action.amount,
+              }
+          }
+        },
+        ({initialY}) => ({
+          y: initialY,
+        }),
+      ),
+      ({x, y, dispatch}) => (
+        <div>
+          <div data-testid={testId}>{x}</div>
+          <div data-testid={`${testId}-y`}>{y}</div>
+          <button onClick={() => dispatch({type: 'incrementByX'})}>
+            increment by X
+          </button>
+          <button
+            onClick={() => dispatch({type: 'incrementByAmount', amount: 2})}
+          >
+            increment by amount
+          </button>
+        </div>
+      ),
+    )
+
+    const testId = 'reducer-over-props-initial-state-function'
+    const {rerender} = render(<Component x={3} initialY={1} testId={testId} />)
+    expect(screen.getByTestId(testId)).toHaveTextContent('3')
+    expect(screen.getByTestId(`${testId}-y`)).toHaveTextContent('1')
+    fireEvent.click(screen.getByText('increment by X'))
+    expect(screen.getByTestId(testId)).toHaveTextContent('3')
+    expect(screen.getByTestId(`${testId}-y`)).toHaveTextContent('4')
+    fireEvent.click(screen.getByText('increment by amount'))
+    expect(screen.getByTestId(testId)).toHaveTextContent('3')
+    expect(screen.getByTestId(`${testId}-y`)).toHaveTextContent('6')
+    rerender(<Component x={4} initialY={1} testId={testId} />)
+    expect(screen.getByTestId(testId)).toHaveTextContent('4')
+    expect(screen.getByTestId(`${testId}-y`)).toHaveTextContent('6')
+    fireEvent.click(screen.getByText('increment by X'))
+    expect(screen.getByTestId(testId)).toHaveTextContent('4')
+    expect(screen.getByTestId(`${testId}-y`)).toHaveTextContent('10')
+  })
 })

--- a/src/addReducerOverProps.tsx
+++ b/src/addReducerOverProps.tsx
@@ -3,7 +3,7 @@ import {isFunction} from 'lodash'
 
 type AddReducerOverPropsType = <TProps, TState, TAction>(
   reducer: (props: TProps) => Reducer<TState, TAction>,
-  initialState: TState,
+  initialState: TState | ((props: TProps) => TState),
 ) => (props: TProps) => TProps & TState & {dispatch: (action: TAction) => void}
 
 const addReducerOverProps: AddReducerOverPropsType = (


### PR DESCRIPTION
In this PR:
- expose `addReducerOverProps()` accepting its initial state as a function of props in its type signature

Fixes #17 