### PR TITLE
Use loading underscores for internal prop names

### DIFF
--- a/src/addDebouncedCopy.tsx
+++ b/src/addDebouncedCopy.tsx
@@ -30,8 +30,8 @@ const addDebouncedCopy: AddDebouncedCopyType = (
   propName,
   debouncedPropName,
 ) => {
-  const setterName = 'addDebouncedCopySetter'
-  const refName = 'addDebouncedCopyRef'
+  const setterName = '_addDebouncedCopy-setter'
+  const refName = '_addDebouncedCopy-ref'
 
   return flowMax(
     addState(

--- a/src/addDebouncedHandler.tsx
+++ b/src/addDebouncedHandler.tsx
@@ -16,8 +16,8 @@ const addDebouncedHandler: AddDebouncedHandlerType = (
   waitInterval,
   handlerPropName,
 ) => {
-  const refName = 'addDebouncedHandlerRef'
-  const invokeRefHandlerName = 'addDebouncedHandlerInvokeRef'
+  const refName = '_addDebouncedHandler-ref'
+  const invokeRefHandlerName = '_addDebouncedHandler-invokeRef'
 
   return flowMax(
     addPropTrackingRef(handlerPropName, refName),

--- a/src/addEffectOnUnmount.tsx
+++ b/src/addEffectOnUnmount.tsx
@@ -8,8 +8,8 @@ type AddEffectOnUnmountType = <TProps>(
 ) => CurriedUnchangedProps<TProps>
 
 const addEffectOnUnmount: AddEffectOnUnmountType = (callback) => {
-  const handlerName = 'addEffectOnUnmountHandler'
-  const handlerRefName = 'addEffectOnUnmountHandlerRef'
+  const handlerName = '_addEffectOnUnmount-handler'
+  const handlerRefName = '_addEffectOnUnmount-handlerRef'
   return flowMax(
     addHandlers({
       [handlerName]: (props) => () => {

--- a/src/addPropIdentityStabilization.tsx
+++ b/src/addPropIdentityStabilization.tsx
@@ -10,40 +10,30 @@ type AddPropIdentityStabilizationType = <
   propName: TPropName,
 ) => CurriedUnchangedProps<TProps>
 
+const refName = '_addPropIdentityStabilization-ref'
+const equalRefName = '_addPropIdentityStabilization-equalRef'
+
 const addPropIdentityStabilization: AddPropIdentityStabilizationType = (
   propName,
 ) =>
   flowMax(
-    addRef(
-      'propIdentityStabilizationRef',
-      ({[propName]: propValue}) => propValue,
-    ),
-    addRef(
-      'propIdentityStabilizationEqualRef',
-      ({[propName]: propValue}) => propValue,
-    ),
+    addRef(refName, ({[propName]: propValue}) => propValue),
+    addRef(equalRefName, ({[propName]: propValue}) => propValue),
     addProps(
-      ({
-        propIdentityStabilizationRef,
-        [propName]: propValue,
-        propIdentityStabilizationEqualRef,
-      }) => {
-        const previousValue = propIdentityStabilizationRef.current
-        const previousEqualValue = propIdentityStabilizationEqualRef.current
+      ({[refName]: ref, [propName]: propValue, [equalRefName]: equalRef}) => {
+        const previousValue = ref.current
+        const previousEqualValue = equalRef.current
         if (previousValue === propValue) return {[propName]: previousValue}
         if (previousEqualValue === propValue) return {[propName]: previousValue}
         if (isEqual(previousValue, propValue)) {
-          propIdentityStabilizationEqualRef.current = propValue
+          equalRef.current = propValue
           return {[propName]: previousValue}
         }
-        propIdentityStabilizationRef.current = propValue
+        ref.current = propValue
         return {[propName]: propValue}
       },
     ),
-    cleanupProps([
-      'propIdentityStabilizationRef',
-      'propIdentityStabilizationEqualRef',
-    ]),
+    cleanupProps([refName, equalRefName]),
   )
 
 export default addPropIdentityStabilization


### PR DESCRIPTION
In this PR:
- use leading underscores for all helper-internal prop names

Fixes #8 

