### PR TITLE
addInterval() accept function of props for delay argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ you should be ready to use it on a Typescript + React project
 ```js
 addInterval(
   callback: (props: Object) => Function,
-  delay: number | null,
+  delay: number | null | ((props: Object) => number | null),
   additionalDependenciesThatShouldTriggerResettingInterval?: string[]
 ): Function
 ```

--- a/src/addInterval.tsx
+++ b/src/addInterval.tsx
@@ -2,10 +2,11 @@ import {CurriedUnchangedProps} from 'ad-hok'
 
 import useInterval from './useInterval'
 import get from './utils/get'
+import isFunction from './utils/isFunction'
 
 type AddIntervalType = <TProps>(
   callback: (props: TProps) => () => void,
-  delay: number | null,
+  delay: number | null | ((props: TProps) => number | null),
   additionalDependenciesThatShouldTriggerResettingInterval?: string[],
 ) => CurriedUnchangedProps<TProps>
 
@@ -16,7 +17,7 @@ const addInterval: AddIntervalType = (
 ) => (props) => {
   useInterval(
     callback(props),
-    delay,
+    isFunction(delay) ? delay(props) : delay,
     additionalDependenciesThatShouldTriggerResettingInterval.map((dependency) =>
       get(dependency, props),
     ),


### PR DESCRIPTION
Fixes #27 

In this PR:
- update `addInterval()` to accept a function of props for its delay argument